### PR TITLE
Add Line endpoints, tests, routes, and seed data

### DIFF
--- a/app/controllers/haikus_controller.rb
+++ b/app/controllers/haikus_controller.rb
@@ -13,20 +13,18 @@ class HaikusController < ApplicationController
   def create
     haiku = Haiku.new(haiku_params)
     if haiku.save
-      render json: haiku
-      head 201
+      render json: haiku.lines, status: 201
     else
-      render json: {errors: haiku.errors}
+      render json: '400', status: 400
     end
   end
 
   def update
     haiku = Haiku.find(params[:id])
-    if haiku.update_attributes(haiku_params)
-      render json: haiku
+    if haiku.lines.first.update_attributes(line_params)
+      render json: haiku.lines
     else
-      render json: {errors: haiku.errors}
-      head 400
+      render json: '400', status: 400
     end
   end
 
@@ -39,7 +37,11 @@ class HaikusController < ApplicationController
   private
 
   def haiku_params
-    params.permit()
+    params.permit(lines_attributes: [:haiku_id, :content])
   end
 
+  def line_params
+    params.permit(:haiku_id, :content)
+  end
+  
 end

--- a/app/controllers/lines_controller.rb
+++ b/app/controllers/lines_controller.rb
@@ -1,0 +1,42 @@
+class LinesController < ApplicationController
+  def index
+    lines = Line.eager_load(:haiku).where("haiku_id = ?", params[:haiku_id])
+    render json: lines, each_serializer: LineSerializer
+  end
+
+  def create
+    line = Line.new(line_params)
+    if line.save
+      render json: line, status: 201
+    else
+      render json: '400', status: 400
+    end
+  end
+
+  def update
+    line = Line.find(params[:id])
+    if line.update_attributes(line_params)
+      render json: line
+    else
+      render json: '400', status: 400
+    end
+  end
+
+  def show
+    line = Line.find(params[:id])
+    render json: line
+  end
+
+  def destroy
+    line = Line.find(params[:id])
+    line.destroy
+    head 204
+  end
+
+  private
+
+    def line_params
+      params.permit(:haiku_id, :content)
+    end
+end
+

--- a/app/models/haiku.rb
+++ b/app/models/haiku.rb
@@ -1,3 +1,5 @@
 class Haiku < ActiveRecord::Base
-  has_many :lines
+  has_many :lines, inverse_of: :haiku
+  accepts_nested_attributes_for :lines
+  validates :lines, presence: true
 end

--- a/app/models/line.rb
+++ b/app/models/line.rb
@@ -1,3 +1,5 @@
 class Line < ActiveRecord::Base
   belongs_to :haiku
+  validates :haiku, presence: true
+  validates :content, presence: true
 end

--- a/app/serializers/line_serializer.rb
+++ b/app/serializers/line_serializer.rb
@@ -1,0 +1,3 @@
+class LineSerializer < ActiveModel::Serializer
+  attributes :id, :haiku_id, :content
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,10 @@ Rails.application.routes.draw do
 
   delete '/sessions/:id' => 'sessions#destroy'
   resources :tags, only: [:create, :update, :destroy], constraints: {format: :json}
-  resources :haikus, constraints: {format: :json}
+  resources :haikus, constraints: {format: :json} do
+    resources :lines, only: [:index, :create, :update, :show, :destroy], constraints: {format: :json}
+  end
+  resources :tags, only: [:create, :update, :destroy], constraints: {format: :json} 
 
   root to: 'haikus#index'
 end

--- a/db/migrate/20151012015539_add_index_to_lines.rb
+++ b/db/migrate/20151012015539_add_index_to_lines.rb
@@ -1,0 +1,5 @@
+class AddIndexToLines < ActiveRecord::Migration
+  def change
+    add_index :lines, :haiku_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150929205233) do
+ActiveRecord::Schema.define(version: 20151012015539) do
 
   create_table "haikus", force: :cascade do |t|
     t.datetime "created_at", null: false
@@ -24,6 +24,8 @@ ActiveRecord::Schema.define(version: 20150929205233) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
+
+  add_index "lines", ["haiku_id"], name: "index_lines_on_haiku_id"
 
   create_table "sessions", force: :cascade do |t|
     t.string   "oauth_token"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,6 +6,12 @@
 #   cities = City.create([{ name: 'Chicago' }, { name: 'Copenhagen' }])
 #   Mayor.create(name: 'Emanuel', city: cities.first)
 
-  5.times do |i|
-    Haiku.create()
-  end
+
+5.times do |i|
+  Haiku.create()
+end
+
+Line.create(haiku_id: 1, content: "This is the first one")
+Line.create(haiku_id: 1, content: "How do I write a haiku")
+Line.create(haiku_id: 1, content: "I can live with this")
+

--- a/spec/requests/haikus_spec.rb
+++ b/spec/requests/haikus_spec.rb
@@ -3,21 +3,22 @@ require 'rails_helper'
 describe 'haikus', type: :request do
 
   describe 'index' do
-    before :each do
-      haikus_list = FactoryGirl.create_list(:haiku, 5)
-      get '/haikus'
-    end
+   before :each do
+     haikus_list = FactoryGirl.create_list(:haiku, 5, {"lines_attributes": {"0": {"content": "Haiku line"}}})
+     get '/haikus'
+  end
+
     it 'should have an endpoint' do
       expect(response).to be_success
     end
-    it 'should return an array of haikus' do
+    it 'should return an array of haikus' do  
       body = JSON.parse(response.body)
       expect(body['data'].length).to eq(5)
     end
   end
 
   describe 'show' do
-    let(:haiku) {FactoryGirl.create(:haiku)}
+    let(:haiku) { FactoryGirl.create(:haiku, {"lines_attributes": {"0": {"content": "haiku line"}}} ) }
     before :each do
       get "/haikus/#{haiku.id}"
     end
@@ -31,23 +32,36 @@ describe 'haikus', type: :request do
   end
 
   describe 'create' do
-    it 'should create a new haiku' do
-      expect{ post '/haikus'}.to change { Haiku.count }.by(1)
+    it 'should create a new haiku with a haiku line' do
+      post '/haikus', {"lines_attributes": {"0": {"content": "haiku line"}}}, format: :json
       expect(response.status).to eq(201)
+      body = JSON.parse(response.body)
+      expect(body["data"][0]["attributes"]["content"]).to eq("haiku line")
     end
-=begin
-    it 'should not create a new haiku without a line' do
-      #spec for making sure haikus wont be created without a line
+    it "should not create a new haiku when line content is missing" do
+      post '/haikus', format: :json
+      expect(response.status).to eq(400)
     end
-=end
   end
 
   describe 'update' do
-    #update spec will be written when haikus are created with a new line
+    let(:haiku) { FactoryGirl.create(:haiku, {"lines_attributes": {"0": {"content": "haiku line"}}} ) }
+    it "should update haiku using valid data" do
+      patch "/haikus/#{haiku.id}", content: "updated haiku line", format: :json
+      expect(response.status).to eq(200)
+      haiku.reload
+      body = JSON.parse(response.body)
+      expect(haiku.lines.first.content).to eq("updated haiku line")
+    end
+
+    it "should not update haiku when missing data" do
+      patch "/haikus/#{haiku.id}", content: nil, format: :json
+      expect(response.status).to eq(400)
+    end
   end
 
   describe 'destroy' do
-    let!(:haiku) { FactoryGirl.create(:haiku) }
+    let!(:haiku) { FactoryGirl.create(:haiku, {"lines_attributes": {"0": {"content": "haiku line"}}} ) }
     it "should delete the haiku" do
       expect{ delete "/haikus/#{haiku.id}", format: :json }.to change{Haiku.count}.by(-1)
     end

--- a/spec/requests/lines_spec.rb
+++ b/spec/requests/lines_spec.rb
@@ -1,0 +1,67 @@
+require 'rails_helper'
+
+describe "lines", type: :request do
+
+  let(:haiku) { FactoryGirl.create(:haiku, {"lines_attributes": {"0": {"content": "haiku line"}}} ) }
+  let(:line) { haiku.lines.first }
+
+  describe "lines#index", type: :request do
+   let!(:line2) { FactoryGirl.create(:line, haiku_id: haiku.id, content: "Line 2") }
+   let!(:line3) { FactoryGirl.create(:line, haiku_id: haiku.id, content: "Line 3") }
+
+    it "should output collection of lines" do
+      get "/haikus/#{haiku.id}/lines", {format: :json}
+      expect(response.status).to eq(200)
+      response_body = JSON.parse(response.body)
+      expect(response_body["data"].length).to eq(3)
+    end
+  end
+
+  describe "lines#create", type: :request do  
+    it "should create line using valid data" do
+      post "/haikus/#{haiku.id}/lines", format: :json, haiku_id: haiku.id, content: "let's make a haiku" 
+      expect(response.status).to eq(201)
+      expect(Line.last.content).to eq("let's make a haiku")
+    end
+
+    it "should not create line when missing data" do
+      post "/haikus/#{haiku.id}/lines", format: :json, content: nil
+      expect(response.status).to eq(400)
+    end
+  end
+
+  describe "lines#update", type: :request do
+    it "should update line using valid data" do
+      patch "/haikus/#{haiku.id}/lines/#{line.id}", content: "haiku has been updated!", format: :json
+      expect(response.status).to eq(200)
+      line.reload
+      expect(line.content).to eq("haiku has been updated!")
+    end
+
+    it "should not update line when missing data" do
+      patch "/haikus/#{haiku.id}/lines/#{line.id}", content: nil, format: :json
+      expect(response.status).to eq(400)
+    end
+  end
+
+  describe "lines#show", type: :request do
+    it "should output line" do
+      get "/haikus/#{haiku.id}/lines/#{line.id}", format: :json
+      expect(response.status).to eq(200)
+      response_body = JSON.parse(response.body)
+      expect(response_body["data"]["attributes"]["content"]).to eq(line.content)
+    end
+  end
+
+  describe "lines#destroy", type: :request do
+    let!(:line) { haiku.lines.first }
+
+    it "should delete line" do
+      count = Line.count
+      delete "/haikus/#{haiku.id}/lines/#{line.id}", format: :json
+      expect(response.status).to eq(204)
+      expect(Line.count).to eq(count - 1)
+    end
+  end
+
+end


### PR DESCRIPTION
Creating a haiku allows user to create a line. Updating a haiku allows user to update the first line. Added index to haiku_id in Lines table. 100% test coverage now.
